### PR TITLE
Added new repo links and clean up some linting warnings

### DIFF
--- a/HelpWanted.md
+++ b/HelpWanted.md
@@ -1,6 +1,6 @@
 # Help Wanted "Template"
 
-The __Help Wanted__ feature of Code.gov will be based off of Github Issues. 
+The __Help Wanted__ feature of Code.gov will be based off of Github Issues.
 
 Github Issues is a quick and easy way to express work to be done on a project and integrates well into modern developer workflow. It's also a good way to keep a single line of communication with your contributor community.
 
@@ -8,7 +8,7 @@ Every Github issue should have the following information for it to be useful:
 
 * __Title:__ a brief summary of what the task is. This is the primary way you will attract contributors.
 * __Issue Description:__ A detailed description of the task. It's important to include any specifics that could help contributors recreate, test, and fix the issue or implement a new feature.
-   * __Contact Info (Name, Email, Telephone #):__ This is totally optional and should only be used if direct communication is important. Our main suggestion is to use the comment functionality provided by Github to keep all relevant issue conversations in one place.
+  * __Contact Info (Name, Email, Telephone #):__ This is totally optional and should only be used if direct communication is important. Our main suggestion is to use the comment functionality provided by Github to keep all relevant issue conversations in one place.
 * __Labels:__ labels are used to identify the issues as a `help wanted` task and to supply Code.gov with needed metadata. Click [here to read about labels](#labels).
 
 ## [Labels](#labels)
@@ -23,34 +23,34 @@ Note: These are custom labels you will have to create one time in your repo, not
 
 Code.gov will use the following labels as Issue Types
 
-- __bug:__ a general bug found in the functionality of your project
-- __enhancement:__ this label works as a catch all for new features, code cleanup, and general code maintenance. Bugs should not have the enhancement label added to them.
-- __good first issue:__ some projects are complex. This label will help your new contributors know that this issue is a great way to get involved with your project.
-- __feedback:__ sometimes you just want to get a different perspective. This label will let your community know that you would like their feedback on a topic.
+* __bug:__ a general bug found in the functionality of your project
+* __enhancement:__ this label works as a catch all for new features, code cleanup, and general code maintenance. Bugs should not have the enhancement label added to them.
+* __good first issue:__ some projects are complex. This label will help your new contributors know that this issue is a great way to get involved with your project.
+* __feedback:__ sometimes you just want to get a different perspective. This label will let your community know that you would like their feedback on a topic.
 
 These lables should be created or modified to follow the template: `[issue-type] <value>`
 
-#### Examples:
+#### Examples
 
-- [issue-type] bug
-- [issue-type] enhancement
-- [issue-type] good first issue
+* [issue-type] bug
+* [issue-type] enhancement
+* [issue-type] good first issue
 
 ### Skill Level
 
 There will be three levels that we will recognize:
 
-- Beginner
-- Intermediate
-- Advanced
+* Beginner
+* Intermediate
+* Advanced
 
-These labels should be created or modified to follow the template: `[skill-level] <value>` 
+These labels should be created or modified to follow the template: `[skill-level] <value>`
 
-#### Examples:
+#### Examples
 
-- [skill-level] beginner
-- [skill-level] intermediate
-- [skill-level] advanced
+* [skill-level] beginner
+* [skill-level] intermediate
+* [skill-level] advanced
 
 ### Effort
 
@@ -58,19 +58,19 @@ Effort will be identified by sizes.
 
 We will recognize three levels of effort:
 
-- small
-- medium
-- large
+* small
+* medium
+* large
 
 Details of why it's one of these levels of effort can be included in the issue description.
 
 The labels should be created or modified to follow the template: `[effort] <value>`
 
-#### Examples:
+#### Examples
 
-- [effort] small
-- [effort] medium
-- [effort] large
+* [effort] small
+* [effort] medium
+* [effort] large
 
 ### Impact
 
@@ -78,28 +78,28 @@ The list of values for impact will probably shrink and grow over time.
 
 We will recognize the following list in the short term:
 
-- census
-- commerce
-- data engineering
-- data science
-- environment
-- general data
-- general tech
-- health
-- homelessness
-- open data
-- open government
-- science and technology
-- security
-- veterans
+* census
+* commerce
+* data engineering
+* data science
+* environment
+* general data
+* general tech
+* health
+* homelessness
+* open data
+* open government
+* science and technology
+* security
+* veterans
 
 The labels should be created or modified to follow the template: `[impact] <value>`
 
-#### Examples:
+#### Examples
 
-- [impact] veterans
-- [impact] health
-- [impact] census
+* [impact] veterans
+* [impact] health
+* [impact] census
 
 ### Featured
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # code-gov
+
 An informative repo for all Code.gov repos
 
-# What is Code.gov?
+## What is Code.gov
 
 [Code.gov](https://code.gov) is a website and program promoting good practices in code development, collaboration, and reuse across the U.S. Government. [Code.gov](https://code.gov) will provide tools and guidance to help agencies implement the [Federal Source Code Policy](https://code.gov/#/policy-guide/policy/introduction). It will include an inventory of the government's custom code to promote reuse between agencies and will provide tools to help government and the public collaborate on open source projects.
 
@@ -9,18 +10,26 @@ To learn more about the project, check out this [blog post](https://www.whitehou
 
 [Code.gov](https://code.gov) is an open source project, so we invite your contributions, be it in the form of code, design, or ideas.
 
-# Repositories
+## Repositories
 
 As a project, [Code.gov](https://code.gov) is a collection of repositories that enable the collection of source code inventory files. All of our work is open source and we encorage you to take a look and, if you wish, contribute to our projects by submitting a pull request, Github Issue, or commenting on existing issues and pull requests.
 
-1. [code-gov-web](https://github.com/GSA/code-gov-web): Our frontend project. Currently deployed as a static site, this project consumes a series of JSON files to display project repositories, client-side search index, and agency compliance dashboard.
-2. [code-gov-api](https://github.com/GSA/code-gov-web): Our backend API. An Express.js app backed by Elasticsearch. Its primary function is to index and make America's source code discoverable and searchable.
-3. [code-gov-harvester](https://github.com/GSA/code-gov-harvester): Our standalone source code inventory harvester. Currently this application generates the files needed by our frontend to display project repositories and our client-side search index. It also generates the data for the agency complaince dashboard.
-4. [code-gov-api-client](https://github.com/GSA/code-gov-api-client): Our JavaScript client for interacting with our backend API.  Use it to search, get all the repos for an agency and more!
+1. [GSA/code-gov-web](https://github.com/GSA/code-gov-web): Our frontend project. Currently deployed as a static site, this project consumes a series of JSON files to display project repositories, client-side search index, and agency compliance dashboard.
+2. [GSA/code-gov-api](https://github.com/GSA/code-gov-web): Our backend API. An Express.js app backed by Elasticsearch. Its primary function is to index and make America's source code discoverable and searchable.
+3. [GSA/code-gov-harvester](https://github.com/GSA/code-gov-harvester): Our standalone source code inventory harvester. Currently this application generates the files needed by our frontend to display project repositories and our client-side search index. It also generates the data for the agency complaince dashboard.
+4. [GSA/code-gov-api-client](https://github.com/GSA/code-gov-api-client): Our JavaScript client for interacting with our backend API.  Use it to search, get all the repos for an agency and more!
+5. [GSA/code-gov-developer-docs](https://github.com/GSA/code-gov-developer-docs): Our developer docs! This repo is meant to be a simple way to start using our API and what you need to do so. It will also let our users get an API token.
+
+### Miscellanious Repositories
+
+These repos are marked as miscellanious because they do not affect the development or deployment of our main repos.
+
+1. [GSA/code-gov-stats](https://github.com/GSA/code-gov-stats)
+2. [GSA/code-gov-stats-jupyter-notebook](https://github.com/GSA/code-gov-stats-jupyter-notebook)
 
 Each of our repositories follow our Code of Conduct and Contributing guidelines.
 
-# Communications
+## Communications
 
 As an open source project we love feedback. If you want to get a hold of us you can use one of the following ways:
 
@@ -34,5 +43,4 @@ You can also [submit an issue](https://github.com/GSA/code-gov/issues/new) on th
 3. [code-gov-harvester issues](https://github.com/GSA/code-gov-harvester/issues)
 4. [code-gov-api-client issues](https://github.com/GSA/code-gov-api-client/issues)
 
-
-# Thanks!!!!!
+## Thanks!


### PR DESCRIPTION
Added our two new repos:

* [GSA/code-gov-stats](https://github.com/GSA/code-gov-stats)
* [GSA/code-gov-stats-jupyter-notebook](https://github.com/GSA/code-gov-stats-jupyter-notebook)

Also cleaned up some Markdown linter warnings.