### PR TITLE
Updated rows of table to split hosted vs cloud

### DIFF
--- a/CODE_JSON_GENERATORS.md
+++ b/CODE_JSON_GENERATORS.md
@@ -12,9 +12,12 @@ The [Code.gov](https://www.code.gov) program and U.S. Government would like to d
 Feature             | [Scraper](https://github.com/llnl/scraper) | [Code-JSON Generator](https://github.com/usgs/code-json-generator) |  [Code-Inventory Generator](https://github.com/GSA/codeinventory-github) | [Code Inventory](https://github.com/GSA/codeinventory) | [Source Code Inventory](https://github.com/HHS/Source-Code-Inventory)
 --------------------|-----------------------|-----------------------|-----------------------|-----------------------|-----------------------|
 Language            | Python                | Node.js | Ruby | Ruby | TBD |
-GitHub.com?         | :white_check_mark:    | :white_check_mark: | :white_check_mark: |  :white_check_mark: | :x: |
-GitLab.com?         | :white_check_mark:    | :white_check_mark: | :x: | :x: | :x: |
-Bitbucket.org?      | :white_check_mark:    | :x: | :x: |  :x: | :x: |
+GitHub.com          | :white_check_mark:    | :white_check_mark: | :white_check_mark: |  :white_check_mark: | :x: |
+GitHub Enterprise   | :white_check_mark:    | :white_check_mark: | :white_check_mark: |  :white_check_mark: | :x: |
+GitLab.com          | :white_check_mark:    | :white_check_mark: | :x: | :x: | :x: |
+GitLab Hosted       | :white_check_mark:    | :white_check_mark: | :x: | :x: | :x: |
+Bitbucket.org       | :x:                   | :x: | :x: |  :x: | :x: |
+Bitbucket Server    | :white_check_mark:    | :x: | :x: |  :x: | :x: |
 Labor Hours         | :white_check_mark:    | :x: | :x: | :x: | :x: |
 Lead Developer		| [IanLee1521](https://github.com/IanLee1521)	| [emartinez-usgs](https://github.com/emartinez-usgs)	| [contolini](https://github.com/contolini) | [jfredrickson5](https://github.com/jfredrickson5) | [katucker](https://github.com/katucker) |
 Agency					|	DOE-LLNL		|	DOI-USGS  		|	CFPB   	|  GSA	 |  HHS |

--- a/CODE_JSON_GENERATORS.md
+++ b/CODE_JSON_GENERATORS.md
@@ -32,10 +32,9 @@ Please see the full list here: [https://github.com/GSA/code-gov/projects/1](http
 ## GSA Code Inventory Tool
 
 The [Code Inventory](https://github.com/GSA/codeinventory) tool is a Ruby gem application that provides basic functionality in a CLI and API, and it can be extended via plug-ins (which are also gems) to support any type of repository
-One plug-in we developed is to add GitHub support: [https://github.com/GSA/codeinventory-github
-]()
+One plug-in we developed is to add GitHub support: [https://github.com/GSA/codeinventory-github](https://github.com/GSA/codeinventory-github)
 
-[https://github.com/GSA/code-clerk](New Code Clerk tool)  
+[New Code Clerk tool](https://github.com/GSA/code-clerk)  
 Designed more as an API/SDK, which can power a CLI tool (it does have a basic CLI included)
 Designed to be extensible: the user can very finely customize how they want to transform their repository metadata into code.json, but it also comes with easy defaults
 Node is more commonly used in web app projects these days, hence the transition to a new language.


### PR DESCRIPTION
Splits the *.com / *.org from the self-hosted repo hosting services. For instance, Scraper currently supports Bitbucket Server (self-hosted) but not Bitbucket.org due to differences in their APIs.