### PR TITLE
Date Created is not a required field, optional - documentation update.

### DIFF
--- a/CODE_JSON_GENERATORS.md
+++ b/CODE_JSON_GENERATORS.md
@@ -15,7 +15,7 @@ GitHub.com          | :white_check_mark:    | :white_check_mark: | :white_check_
 GitHub Enterprise   | :white_check_mark:    | :white_check_mark: | :white_check_mark: |  :white_check_mark: | :x: |
 GitLab.com          | :white_check_mark:    | :white_check_mark: | :x: | :x: | :x: |
 GitLab Hosted       | :white_check_mark:    | :white_check_mark: | :x: | :x: | :x: |
-Bitbucket.org       | :x:                   | :x: | :x: |  :x: | :x: |
+Bitbucket.org       | :white_check_mark:    | :x: | :x: |  :x: | :x: |
 Bitbucket Server    | :white_check_mark:    | :x: | :x: |  :x: | :x: |
 Team Foundation Server (TSF)    | :white_check_mark:    | :x: | :x: |  :x: | :x: |
 Labor Hours         | :white_check_mark:    | :x: | :x: | :x: | :x: |

--- a/data_quality_scoring.md
+++ b/data_quality_scoring.md
@@ -4,55 +4,68 @@ As part of our efforts to make Code.gov as useful as possible to our users, we h
 
 ## Score Determination
 
-We determine the quality score of a repository by using a series of rules and passing the repository through a rules engine. We also assign a __weight__ to each field that symbolizes the value that field has for Code.gov.
+We determine the quality score of a repository by using a series of rules and passing the repository through a rules engine. We also assign a __point value__ to each field that symbolizes the value that field has for Code.gov.
 
 The rules can vary from field to field. As an example, we evaluate the existance of data in all fields before we add their weight to the overall score, but in the case of the __description__ field we also evaluate that the content of the field is not the same as the name of the project and we make a "naive" evaluation on the amount of content that the field has (word count). Other fields are evaluated depending on the data that is expected and desired in them.
 
-### Field Weights
+### Field Points
 
-We give weight values between 0 and 1. These values are the maximum score that data in the field can obtain. There are fields where data is evaluated and may be awared less than the values in the following table. There are other fields, like the tags field that may accumulate scores depending on the amount of data submitted (Eg. each tag contributes the field value).
+We give point values between 0 and 10. These values are the maximum score that data in the field can obtain. There are fields where data is evaluated and may be awared less than the values in the following table.  Also, fields like tags may be awarded partial value based on number of items
 
-| Field Name                | Field Weight |
-| ------------------------- | ------------ |
-| name                      | 1            |
-| description               | 1            |
-| permissions.licenses      | 1            |
-| permissions.licenses.URL  | 1            |
-| permissions.licenses.name | 1            |
-| permissions.usageType     | 1            |
-| permissions.exemptionText | 1            |
-| organization              | 1            |
-| contact.email             | 1            |
-| contact.name              | 1            |
-| contact.URL               | 1            |
-| contact.phone             | 1            |
-| tags                      | 1            |
-| laborHours                | 1            |
-| languages:                | 0.8          |
-| repositoryURL:            | 0.8          |
-| homepageURL:              | 0.8          |
-| downloadURL:              | 0.8          |
-| vcs:                      | 0.8          |
-| date.created:             | 0.6          |
-| date.lastModified:        | 0.6          |
-| date.metadataLastUpdated: | 0.6          |
-| version:                  | 0.6          |
-| status:                   | 0.6          |
-| disclaimerURL:            | 0.4          |
-| disclaimerText:           | 0.4          |
-| relatedCode.name:         | 0.4          |
-| relatedCode.URL:          | 0.4          |
-| reusedCode.name:          | 0.4          |
-| reusedCode.URL:           | 0.4          |
-| partners.name:            | 0.4          |
-| partners.email:           | 0.4          |
-| target_operating_systems: | 0.2          |
-| additional_information:   | 0.1          |
+|Field Name|Max Field Points|Required|Notes|
+|-|-|-|-|
+|name|10|yes||
+|version|1|yes|||
+|organization|5|||
+|description|10|yes|0 points if descriptions and name are same, 0 points if description is less then 3 words, 3 points if description is less then 10 words, 5 points if description is less then 20 words, 8 points if description is less then 30 words, 10 (full) points if description is 30 or more words |
+|permissions.licenses.URL|1||Licenses is an Array of objects and it should have atleast 1 element|
+|permissions.licenses.name|7||Licenses is an Array of objects and it should have atleast 1 element|
+|permissions.usageType|10|yes|1 point if exempt*, 5 points if governmentWideReuse, 10 (full) points if openSource'|
+|permissions.exemptionText|5||5 (full) points if usageType is openSource/governmentWideReuse OR exemptionText is present, 0 otherwise|
+|tags|10|yes|Tags is an Array objects, 4 points if 1 tag element, 6 points if 2 tag elements, 10 (full) points if 3 or more tag elements|
+|contact.email|10|yes||
+|contact.name|5|||
+|contact.URL|5|||
+|contact.phone|5||
+|status|5|||
+|vcs|5|||
+|repositoryURL|10|yes|10 (full) points if valid URL (starts with https:// or http://)|
+|homepageURL|7||must exists and be a valid URL to get full points|
+|downloadURL|3||must exists and be a valid URL to get full points|
+|disclaimerURL|3||must exists and be a valid URL to get full points|
+|disclaimerText|3|||
+|languages|10||Languages is an Array of strings, must have atleast 1 element to get full points|
+|laborHours|10|yes|Full points if a positive numeric value|
+|relatedCode.name|1|||
+|relatedCode.URL|1||must exists and be a valid URL to get full points|
+|relatedCode.isGovernmentRepo|1|||
+|reusedCode.name|1|||
+|reusedCode.URL|1||must exists and be a valid URL to get full points|
+|partners.name|1|||
+|partners.email|1|||
+|date.created|5|||
+|date.lastModified|5|||
+|date.metadataLastUpdated|2|||
 
 ### Field Rules
 
-We are using the [simple-rules-engine](https://www.npmjs.com/package/simple-rules-engine) package to evaluate the rules we've created for each field. Our current rules can be seen [here](https://github.com/GSA/code-gov-api/blob/master/services/validator/rules/index.js).
+We are using the [simple-rules-engine](https://www.npmjs.com/package/simple-rules-engine) package to evaluate the rules we've created for each field. Our current rules can be seen [here](https://github.com/GSA/code-gov-harvester/blob/master/libs/rules/index.js).
 
 ### Score Normalization
 
-We are currently in the process of normalizing the scores of our data. After this development is completed all scores will be between 1 and 10 points. This will give our users an easier way to interprete our data quality scores.
+Score normalization is performed where the final score is between 0 and 10.  To arrive at this value, all point values of each field in the above table are tallied and divided by maximum possible point and then multipled by 10.
+
+### Score Display
+
+The code.gov front end uses a [corner tag](https://gsa.github.io/code-gov-style/components/corner_tags) to display the data quality score. This is implemented by the `quality-tag` component. The tag type/color is determined by the `score` value passed to the component using the following ranges:
+- low/red: a score below 4 
+- medium/orange: a score greater than or equal to 4 and less than 6
+- high/green: a score higher than or equal to 6
+
+*Note: because all code.gov projects should have the required fields filled, the majority of projects will have the medium/orange data quality corner tag. 
+
+Check out our [Metadata Examples document](https://github.com/GSA/code-gov/blob/master/METADATA_EXAMPLES.md) for additional information on metadata to include in order to raise your data quality score. 
+
+For more info on the code.gov corner tags see the [style guide](https://gsa.github.io/code-gov-style/components/corner_tags).
+
+See [quality_tag.js](https://github.com/GSA/code-gov-style/blob/master/src/quality_tag.js) to view the code for this corner tag component logic.


### PR DESCRIPTION
Updating the Data Quality Score documentation. The Date Created is not a required field. It's an optional field on the current Metadata Schema 2.0.0