### PR TITLE
Fixed Metadata Examples broken link

### DIFF
--- a/docs/data_quality_scoring.md
+++ b/docs/data_quality_scoring.md
@@ -64,7 +64,7 @@ The code.gov front end uses a [corner tag](https://gsa.github.io/code-gov-style/
 
 *Note: because all code.gov projects should have the required fields filled, the majority of projects will have the medium/orange data quality corner tag. 
 
-Check out our [Metadata Examples document](https://github.com/GSA/code-gov/blob/master/METADATA_EXAMPLES.md) for additional information on metadata to include in order to raise your data quality score. 
+Check out our [Metadata Examples document](https://github.com/GSA/code-gov/blob/master/docs/metadata_examples.md) for additional information on metadata to include in order to raise your data quality score. 
 
 For more info on the code.gov corner tags see the [style guide](https://gsa.github.io/code-gov-style/components/corner_tags).
 


### PR DESCRIPTION
Some of the links were broken after the docs folder cleanup addressed in this issue.
https://github.com/GSA/code-gov/issues/54

There is also a broken link on this page https://code.gov/about/compliance/inventory-code

Tried to find the code for that page, but not sure if that site is also open source.